### PR TITLE
chore(ci): improve GitHub Actions workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,10 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    groups:
+      golangci-lint:
+        patterns:
+          - "golangci*"
+      ci:
+        patterns:
+          - "*"

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -14,45 +14,38 @@ concurrency:
   group: ${{ format('{0}-{1}', github.workflow, github.head_ref) }}
   cancel-in-progress: true
 
-env:
-  GO: "1.24"
-
 permissions: read-all
 
 jobs:
   UnitTests:
     runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4.2.2 # immutable action, safe to use a version instead of hashtag
-
-      - name: Install Go
-        uses: actions/setup-go@v5.5.0 # immutable action, safe to use a version instead of hashtag
+      - uses: actions/checkout@v4.2.2 # immutable action, safe to use a version instead of hashtag
+      - uses: actions/setup-go@v5.5.0 # immutable action, safe to use a version instead of hashtag
         with:
-          go-version: ${{ env.GO }}
-
-      - name: Run Unit Tests
-        run: go test -race -cover -coverprofile=coverage.out -covermode=atomic
-
-      - name: Codecov
+          go-version-file: go.mod
+      - run: go install github.com/jstemmer/go-junit-report/v2@latest
+      - run: go test -race -cover -coverprofile=coverage.out -covermode=atomic
+      - run: go test -json 2>&1 | go-junit-report -parser gojson > junit.xml
+        if: always()
+      - name: Upload coverage reports to Codecov
+        if: ${{ !cancelled() }}
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@f2dba722c67b86c6caa034178c6e4d35335f6706 # v1.1.0
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   GolangCI-Lint:
     runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4.2.2 # immutable action, safe to use a version instead of hashtag
-
-      - name: Install Go
-        uses: actions/setup-go@v5.5.0 # immutable action, safe to use a version instead of hashtag
+      - uses: actions/checkout@v4.2.2 # immutable action, safe to use a version instead of hashtag
+      - uses: actions/setup-go@v5.5.0 # immutable action, safe to use a version instead of hashtag
         with:
-          go-version: ${{ env.GO }}
-
-      - name: Run GolangCi-Lint
-        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
+          go-version-file: go.mod
+      - uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
           version: latest


### PR DESCRIPTION
Refactor GitHub Actions workflows to simplify steps by removing
redundant names and environment variables. Use go.mod to specify
Go version instead of a fixed env variable. Add installation of
go-junit-report and generate JUnit XML test reports for better
test result visualization. Upload test results alongside coverage
to Codecov. Enhance Dependabot config with grouping for golangci-lint
and CI dependencies.