### PR TITLE
docs: update copyright and add install instructions

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Tools
+Copyright (c) 2021 SV Tools
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@
 
 The [conf](https://github.com/sv-tools/conf) reader for Environment Variables.
 
+```shell
+go get github.com/sv-tools/conf-reader-env
+```
+
 ## License
 
 MIT licensed. See the bundled [LICENSE](LICENSE) file for more details.


### PR DESCRIPTION
Change copyright holder in LICENSE to "SV Tools" to reflect the
correct ownership. Add installation instructions to README to
guide users on how to get the conf-reader-env package using go.